### PR TITLE
Modified the build.sbt to work when there is a local version of Scalify

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: scala
 scala:
   - 2.12.8
 jdk:
-  - oraclejdk8
+  - oraclejdk11
 
 env:
   - JOB=Test

--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,5 @@
+import Dependencies._
+
 // Publishing Information
 name := """scalify-play-example"""
 organization := "com.github.fulrich"
@@ -5,40 +7,32 @@ licenses := List("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0
 version := "1.0.0-SNAPSHOT"
 scalaVersion := "2.12.8"
 
-// Play Framework Plugins
-lazy val root = (project in file(".")).enablePlugins(PlayScala)
-
-
-// Versions
-val V = new {
-  val Scalify = "0.0.17"
-  val ScalaTest = "4.0.2"
-  val TestCharged = "0.1.12"
-}
-
 // Resolvers
 resolvers ++= Seq(
   Resolver.sonatypeRepo("releases"),
   Resolver.sonatypeRepo("public")
 )
 
+// Setup App Settings
+lazy val root = (project in file("."))
+  .dependsOn(Development.ScalifyDependsOn: _*)
+  .enablePlugins(PlayScala)
+
 // Production Dependencies
+libraryDependencies ++= Development.ScalifyLibraryDependencies
+
 libraryDependencies ++= Seq(
   guice,
   caffeine,
   ws,
-  "com.github.fulrich" %% "scalify" % V.Scalify,
-  "com.github.fulrich" %% "scalifyplus-play" % V.Scalify,
   "com.github.pureconfig" %% "pureconfig" % "0.11.0",
   "io.lemonlabs" %% "scala-uri" % "1.4.5"
 )
 
 // Test Dependencies
 libraryDependencies ++= Seq(
-  "org.scalatestplus.play" %% "scalatestplus-play" % V.ScalaTest % Test,
-  "com.github.fulrich" %% "test-charged" % V.TestCharged % Test,
-  "com.github.fulrich" %% "scalify" % V.Scalify % Test classifier "tests",
-  "com.github.fulrich" %% "scalifyplus-play" % V.Scalify % Test classifier "tests"
+  Dependencies.ScalaTest.PlusPlay % Test,
+  Dependencies.TestCharged.Core % Test,
 )
 
 // Adds additional packages into Twirl

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,0 +1,20 @@
+import sbt._
+
+// Versions
+object Dependencies {
+  val Scalify = new {
+    val Version = "0.0.17"
+    val Core = "com.github.fulrich" %% "scalify" % Version
+    val PlusPlay = "com.github.fulrich" %% "scalifyplus-play" % Version
+  }
+
+  val ScalaTest = new {
+    val Version = "4.0.2"
+    val PlusPlay = "org.scalatestplus.play" %% "scalatestplus-play" % Version
+  }
+
+  val TestCharged = new {
+    val Version = "0.1.12"
+    val Core = "com.github.fulrich" %% "test-charged" % Version
+  }
+}

--- a/project/Development.scala
+++ b/project/Development.scala
@@ -1,0 +1,23 @@
+import sbt._
+
+object Development {
+  val ScalifyProjectFile = file("../scalify/")
+  val DevelopmentMode: Boolean = ScalifyProjectFile.exists
+  val ProductionMode: Boolean = !DevelopmentMode
+
+  val ScalifyDependsOn: Seq[ClasspathDep[ProjectReference]] =
+    if (ProductionMode) Seq.empty
+    else Seq (
+      ProjectRef(ScalifyProjectFile, "scalify")  % "test->test;compile->compile",
+      ProjectRef(ScalifyProjectFile, "scalifyplusplay")  % "test->test;compile->compile"
+    )
+
+  val ScalifyLibraryDependencies: Seq[ModuleID] =
+    if (DevelopmentMode) Seq.empty
+    else Seq(
+      Dependencies.Scalify.Core,
+      Dependencies.Scalify.PlusPlay,
+      Dependencies.Scalify.Core % Test classifier "tests",
+      Dependencies.Scalify.PlusPlay % Test classifier "tests"
+    )
+}


### PR DESCRIPTION
This CR creates a new modification of the build.sbt file. Basically if the `scalify-play-example` detects a folder `scalify` at the same root as itself it will assume this is the `scalify` project sources. 

**In the case of `scalify` folder being detected:** 
The `build.sbt` will include the local `scalify` and `scalifyplus-play` projects as `test` and `build` dependencies of `scalify-play-example`
The `build.sbt` will not add the maven JAR dependencies to `scalify` or `scalifyplus-play`.

**In the case of `scalify` folder not being detected:** 
The `build.sbt` will not include the local `scalify` and `scalifyplus-play` projects as dependencies.
The `build.sbt` will add the maven JAR dependencies to `scalify` or `scalifyplus-play`.